### PR TITLE
Replace numpy types by their parent class

### DIFF
--- a/dynamo_pandas/serde/serde.py
+++ b/dynamo_pandas/serde/serde.py
@@ -32,12 +32,10 @@ class TypeSerializer(DDBTypeSerializer):
         elif isinstance(value, (pd.Timestamp, pd.Timedelta)):
             dynamodb_type = STRING
 
-        elif isinstance(value, (np.int8, np.int16, np.int32, np.int64)):
+        elif isinstance(value, (int, np.integer)):
             dynamodb_type = NUMBER
 
-        elif isinstance(
-            value, (float, np.float16, np.float32, np.float64, np.float128)
-        ):
+        elif isinstance(value, (float, np.floating)):
             if np.isnan(value):
                 dynamodb_type = NULL
             else:


### PR DESCRIPTION
Fixes #12.

Replace individual numpy int and float types by their parent class (`np.integer`, `np.floating`) in `TypeSerializer` decision tree.