### PR TITLE
Add Windows testing to CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,11 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-20.04, windows-latest]
         python-version: [3.7, 3.8, 3.9]
         pandas: [10, latest]
         exclude:
         - python-version: 3.9
           pandas: "10"
+        - python-version: 3.8
+          os: windows-latest
+        - python-version: 3.7
+          os: windows-latest
+          pandas: latest
         include:
         - python-version: 3.7
           pandas: "10"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit-tests:
 
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fixes #13 

Test only oldest (python 3.7 - pandas 1.0) and latest (python 3.9 - pandas latest) on Windows.