### PR TITLE
Refactor main module

### DIFF
--- a/dynamo_pandas/__init__.py
+++ b/dynamo_pandas/__init__.py
@@ -1,10 +1,7 @@
 from .dynamo_pandas import get_df
 from .dynamo_pandas import keys
 from .dynamo_pandas import put_df
-from .dynamo_pandas import to_df
-from .dynamo_pandas import to_item
-from .dynamo_pandas import to_items
 
 __version__ = "0.1.0"
 
-__all__ = ["get_df", "keys", "put_df", "to_df", "to_item", "to_items", "__version__"]
+__all__ = ["get_df", "keys", "put_df", "__version__"]

--- a/dynamo_pandas/dynamo_pandas.py
+++ b/dynamo_pandas/dynamo_pandas.py
@@ -116,7 +116,7 @@ def get_df(*, table, keys=None, dtype=None):
     else:
         items = get_all_items(table=table)
 
-    return to_df(items=items, dtype=dtype)
+    return _to_df(items=items, dtype=dtype)
 
 
 def keys(**kwargs):
@@ -181,10 +181,10 @@ def put_df(df, *, table):
 
     >>> put_df(players_df, table="players")
     """
-    put_items(items=to_items(df), table=table)
+    put_items(items=_to_items(df), table=table)
 
 
-def to_df(items, *, dtype=None):
+def _to_df(items, *, dtype=None):
     """Convert an item dictionary or list of item dictionaries into a pandas DataFrame.
     """
     if isinstance(items, dict):
@@ -198,28 +198,9 @@ def to_df(items, *, dtype=None):
     return df
 
 
-def to_items(df):
+def _to_items(df):
     """Convert a pandas dataframe to a dictionary of items."""
     if not isinstance(df, pd.DataFrame):
         raise TypeError("df must be a pandas DataFrame")
 
     return df.to_dict("records")
-
-
-def to_item(obj):
-    """Convert a pandas Series or a single row pandas DataFrame to an item dictionary.
-    """
-    if isinstance(obj, pd.DataFrame):
-        if len(obj) != 1:
-            raise ValueError(
-                "obj must be a single row dataframe. Use the to_items function to "
-                + "convert a multi row dataframe."
-            )
-
-        return obj.to_dict("records")[0]
-
-    elif isinstance(obj, pd.Series):
-        return obj.to_dict()
-
-    else:
-        raise TypeError("obj must be a pandas Series or a single row pandas DataFrame")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,9 +7,8 @@ from test_data import test_df
 from dynamo_pandas import get_df
 from dynamo_pandas import keys
 from dynamo_pandas import put_df
-from dynamo_pandas import to_df
-from dynamo_pandas import to_item
-from dynamo_pandas import to_items
+from dynamo_pandas.dynamo_pandas import _to_df
+from dynamo_pandas.dynamo_pandas import _to_items
 
 # List of item dictionaries with pandas dtypes
 test_items_pd = test_df.to_dict("records")
@@ -197,12 +196,12 @@ class Test_put_df:
         )
 
 
-class Test_to_df:
-    """Test the to_df function."""
+class Test__to_df:
+    """Test the _to_df function."""
 
     def test_single_item_dict(self):
         """Test conversion of a single item dictionary."""
-        df = to_df(test_items[0])
+        df = _to_df(test_items[0])
 
         assert df.equals(pd.DataFrame([test_items[0]]))
         assert [t.name for t in df.dtypes] == [
@@ -218,7 +217,7 @@ class Test_to_df:
 
     def test_multiple_item_dicts(self):
         """Test conversion of a list of item dictionaries."""
-        df = to_df(test_items)
+        df = _to_df(test_items)
 
         assert df.equals(pd.DataFrame(test_items))
         assert [t.name for t in df.dtypes] == [
@@ -234,7 +233,7 @@ class Test_to_df:
 
     def test_with_dtype(self):
         """Test with dtype parameter specified."""
-        df = to_df(
+        df = _to_df(
             test_items,
             dtype=dict(
                 # C="timedelta64[ns]",  # Ref. #24
@@ -256,49 +255,12 @@ class Test_to_df:
         ]
 
 
-class Test_to_item:
-    """Test the to_item function."""
-
-    @pytest.mark.parametrize("id", range(3))
-    def test_df_single_row(self, id):
-        """Test conversion of a single dataframe row."""
-        item = to_item(test_df.loc[test_df.id == id])
-
-        if id == 0:
-            assert item == test_items_pd[id]
-        else:
-            # Compare dictionary string values as pd.NA and np.nan fail comparison
-            assert str(item) == str(test_items_pd[id])
-
-    def test_df_multiple_rows_raises(self):
-        """Test that a dataframe with multiple rows raises a ValueError."""
-        with pytest.raises(
-            ValueError,
-            match="obj must be a single row dataframe. Use the to_items function",
-        ):
-            to_item(test_df)
-
-    def test_series(self):
-        """Test conversion of a pandas series."""
-        item = to_item(test_df.iloc[0])
-
-        assert item == test_items_pd[0]
-
-    def test_invalid_type_raises(self):
-        """Test that a type other than a dataframe or series raises a TypeError."""
-        with pytest.raises(
-            TypeError,
-            match="obj must be a pandas Series or a single row pandas DataFrame",
-        ):
-            to_item(test_items_pd[0])
-
-
-class Test_to_items:
-    """Test the to_items function."""
+class Test__to_items:
+    """Test the _to_items function."""
 
     def test_df(self):
         """Test that a dataframe converts to a list of item dictionaries."""
-        items = to_items(test_df)
+        items = _to_items(test_df)
 
         # Compare dictionary string values as pd.NA and np.nan fail comparison
         assert str(items) == str(test_items_pd)
@@ -306,4 +268,4 @@ class Test_to_items:
     def test_invalid_type_raises(self):
         """Test that a type different than a DataFrame raises a TypeError."""
         with pytest.raises(TypeError, match="df must be a pandas DataFrame"):
-            to_items(test_items_pd)
+            _to_items(test_items_pd)


### PR DESCRIPTION
Fixes #30.

Make `to_df` and `to_items` functions private and remove `to_item` function.