### PR TITLE
Set boto3 as optional requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,23 @@ The project's documentation is available at https://dynamo-pandas.readthedocs.io
 
 ## Requirements
 * `python>=3.7`
-* `boto3`
 * `pandas>=1`
+* `boto3`
 
 ## Installation
 
 ```
 python -m pip install dynamo-pandas
 ```
+
+This will install the package and its dependencies except for `boto3` which is not installed by default to avoid unnecessary installation when building Lambda layers.
+
+To include `boto3` as part of the installation, add the `boto3` "extra" this way:
+
+```
+python -m pip install dynamo-pandas[boto3]
+```
+
 ## Example Usage
 
 Consider the pandas DataFrame below.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,11 +13,20 @@ Install ``dynamo-pandas`` from `PyPI <https://pypi.org/project/dynamo-pandas/>`_
     $ pip install dynamo-pandas
 
 
+This will install the package and its dependencies except for `boto3` which is not installed by default to avoid unnecessary installation when building Lambda layers.
+
+To include `boto3` as part of the installation, add the `boto3` "extra" this way:
+
+.. code-block:: console
+
+    $ python -m pip install dynamo-pandas[boto3]
+
+
 Requirements
 ------------
 
 ``dynamo-pandas`` has the following requirements:
 
 * ``python`` >= 3.7
-* ``boto3``
 * ``pandas`` >= 1
+* ``boto3``

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,9 @@
 black==19.10b0
-boto3
 coverage
 flake8==3.8.4
 interrogate
 isort==5.7.0
 moto
-pandas
 pre-commit
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,10 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(),
     python_requires=">=3.7",
-    install_requires=["boto3", "pandas>=1"],
+    install_requires=["pandas>=1"],
+    extras_require={"boto3": ["boto3"]},
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ setenv =
     AWS_DEFAULT_REGION=us-east-1
 download = true
 deps =
+    .[boto3]
     -rrequirements-dev.txt
     pandas10: pandas>=1,<1.1
 commands = pytest -v --cov={envsitepackagesdir}/dynamo_pandas {posargs}


### PR DESCRIPTION
Fixed #35 

Set boto3 as optional requirement to avoid unnecessary installation when building lamda layers.

Remove package dependencies from requirements-dev.txt and install pacakge them via tox deps parameter.

Update installation section of README and docs to reflect the new "extra".