### PR TITLE
Fix handling of unprocessed items in put_items

### DIFF
--- a/dynamo_pandas/transactions/transactions.py
+++ b/dynamo_pandas/transactions/transactions.py
@@ -253,6 +253,23 @@ def put_item(*, item, table, return_response=False):
         return response
 
 
+def _put_items(items, table):
+    """Adapter function to format the items, call the client batch_write_item function
+    and return the unprocessed items (if any) in the format they were provided."""
+    client = boto3.client("dynamodb")
+
+    response = client.batch_write_item(
+        RequestItems={table: [{"PutRequest": {"Item": item}} for item in items]}
+    )
+
+    if response["UnprocessedItems"] != {}:
+        return [
+            item["PutRequest"]["Item"] for item in response["UnprocessedItems"][table]
+        ]
+    else:
+        return []
+
+
 def put_items(*, items, table):
     """Add or update multiple items in a table. If the item(s) do not exist in the
     table they are created, otherwise the existing items are replaced with the new ones.
@@ -286,17 +303,6 @@ def put_items(*, items, table):
     if not isinstance(items, list):
         raise TypeError("items must be a list of non-empty dictionaries")
 
-    def _put_items(items, table=table):
-        response = client.batch_write_item(
-            RequestItems={table: [{"PutRequest": {"Item": item}} for item in items]}
-        )
-        if response["UnprocessedItems"] != {}:
-            return response["UprocessedItems"][table]
-        else:
-            return []
-
-    client = boto3.client("dynamodb")
-
     items_to_process = [i["M"] for i in ts.serialize(items)["L"]]
 
     batch_size = 25
@@ -304,10 +310,10 @@ def put_items(*, items, table):
         batch_items = items_to_process[:batch_size]
         items_to_process = items_to_process[batch_size:]
 
-        unprocessed_items = _put_items(batch_items)
+        unprocessed_items = _put_items(batch_items, table)
 
         if len(unprocessed_items) > batch_size // 2:
-            batch_size = batch_size // 2 + 1
+            batch_size = max(batch_size // 2, 1)
 
         # Put unprocessed items at back of queue.
         items_to_process.extend(unprocessed_items)

--- a/dynamo_pandas/transactions/transactions.py
+++ b/dynamo_pandas/transactions/transactions.py
@@ -135,6 +135,7 @@ def get_items(*, keys, table, attributes=None):
         items = response["Responses"][table]
 
         while response["UnprocessedKeys"] != {}:
+            keys = response["UnprocessedKeys"][table]["Keys"]
             response = resource.batch_get_item(RequestItems=_request(keys))
             items.extend(response["Responses"][table])
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,6 +1,7 @@
 import base64
 import os
 import sys
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -357,3 +358,27 @@ class Test_put_items:
             TypeError, match="items must be a list of non-empty dictionaries"
         ):
             put_items(items=large_table_items[0], table=empty_table)
+
+    def test_unprocessed_items(self, ddb_client, empty_table):
+        """Test the handling of unprocessed items returned by the
+        boto3.client().batch_write_item function."""
+
+        def batch_write_item(RequestItems):
+            """Fake batch_write_item function returning half of the items received."""
+            items = RequestItems[empty_table]
+            response = {
+                "UnprocessedItems": {
+                    empty_table: [
+                        {"PutRequest": {"Item": item}}
+                        for item in items[max(len(items) // 2, 12) :]  # noqa: E203
+                    ]
+                }
+            }
+            return response
+
+        with mock.patch("dynamo_pandas.transactions.transactions.boto3") as boto3:
+            boto3.client().batch_write_item.side_effect = batch_write_item
+
+            items = large_table_items
+
+            put_items(items=items, table=empty_table)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     .[boto3]
     -rrequirements-dev.txt
     pandas10: pandas>=1,<1.1
-commands = pytest -v --cov={envsitepackagesdir}/dynamo_pandas {posargs}
+commands = pytest -v --cov={envsitepackagesdir}/dynamo_pandas --cov-report term-missing {posargs}
 
 [testenv:linting]
 basepython = python3.7


### PR DESCRIPTION
Fix handling of unprocessed items in `transactions.put_items`.
- Fix typo in dictionary key (#42).
- Return unprocessed items in same format as input items (#44).

Also fix handling of unprocessed keys in `transactions.get_items` (#46).

Add testing of handling of unprocessed items & keys (#43, #46).

Fixes #42
Fixes #43 
Fixes #44 
Fixes #46