### PR TITLE
Add Python 3.10 to tox and CI

### DIFF
--- a/.github/workflows/linux-checks.yml
+++ b/.github/workflows/linux-checks.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '40 22 * * 6'
+    - cron: "40 22 * * 6"
 
 jobs:
   unit-tests:
@@ -15,10 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         pandas: [10, latest]
         exclude:
         - python-version: 3.9
+          pandas: "10"
+        - python-version: "3.10"
           pandas: "10"
         include:
         - python-version: 3.7
@@ -36,6 +38,9 @@ jobs:
         - python-version: 3.9
           pandas: latest
           tox_env: py39-pandaslatest
+        - python-version: "3.10"
+          pandas: latest
+          tox_env: py310-pandaslatest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/windows-checks.yml
+++ b/.github/workflows/windows-checks.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    - cron: '40 22 * * 6'
+    - cron: "40 22 * * 6"
 
 jobs:
   unit-tests:
@@ -15,10 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         pandas: [10, latest]
         exclude:
         - python-version: 3.9
+          pandas: "10"
+        - python-version: "3.10"
           pandas: "10"
         include:
         - python-version: 3.7
@@ -36,6 +38,9 @@ jobs:
         - python-version: 3.9
           pandas: latest
           tox_env: py39-pandaslatest
+        - python-version: "3.10"
+          pandas: latest
+          tox_env: py310-pandaslatest
 
     steps:
     - uses: actions/checkout@v2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/conf.py
+
+python:
+  install:
+  - method: pip
+    path: .
+  - requirements: requirements-dev.txt

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.10
-envlist = py{37, 38}-pandas10, py{37, 38, 39}-pandaslatest, linting
+envlist = py{37, 38}-pandas10, py{37, 38, 39, 310}-pandaslatest, linting
 
 [testenv]
 setenv =
@@ -27,3 +27,4 @@ filterwarnings =
     error
     ignore:.*is a deprecated alias:DeprecationWarning
     ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:The distutils package:DeprecationWarning


### PR DESCRIPTION
Add Python 3.10 tox environment and add this environment to GH actions CI workflows.

Fixes #58.