### PR TITLE
Ignore distutil DeprecationWarning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,3 +28,4 @@ filterwarnings =
     ignore:.*is a deprecated alias:DeprecationWarning
     ignore:numpy.ufunc size changed:RuntimeWarning
     ignore:The distutils package:DeprecationWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning


### PR DESCRIPTION
Do not fail CI on distutil DeprecationWarning issued in environments using older pandas versions.