### PR TITLE
Fix failing CI by replacing deprecated moto mock_dynamodb2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   - id: requirements-txt-fixer
 
 - repo: https://github.com/psf/black
-  rev: 19.10b0
+  rev: 22.3.0
   hooks:
   - id: black
 

--- a/dynamo_pandas/dynamo_pandas.py
+++ b/dynamo_pandas/dynamo_pandas.py
@@ -216,8 +216,8 @@ def put_df(df, *, table, boto3_kwargs={}):
 
 
 def _to_df(items, *, dtype=None):
-    """Convert an item dictionary or list of item dictionaries into a pandas DataFrame.
-    """
+    """Convert an item dictionary or list of item dictionaries into a pandas
+    DataFrame."""
     if isinstance(items, dict):
         items = [items]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import base64
 import os
 
 import boto3
-from moto import mock_dynamodb2
+from moto import mock_dynamodb
 import pytest
 from test_data import large_table_items
 from test_data import test_df
@@ -23,7 +23,7 @@ def aws_credentials():
 @pytest.fixture()
 def ddb_client(aws_credentials):
     """Fixture to mock the dynamodb client using moto."""
-    with mock_dynamodb2():
+    with mock_dynamodb():
         yield boto3.client("dynamodb")
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -88,8 +88,8 @@ class Test_get_df:
         )
 
     def test_keys(self, test_df_table):
-        """"Test with keys specified. Also test that keys not in the table are ignored.
-        """
+        """Test with keys specified. Also test that keys not in the table are
+        ignored."""
         df = get_df(table=test_df_table, keys=[{"id": 0}, {"id": 2}, {"id": 3}])
 
         assert {c: t.name for c, t in zip(df.columns, df.dtypes)} == {
@@ -207,7 +207,9 @@ class Test_get_df:
 
         # With the correct region we expect to get the items.
         df = get_df(
-            keys=keys, table=test_df_table, boto3_kwargs=dict(region_name="us-east-1"),
+            keys=keys,
+            table=test_df_table,
+            boto3_kwargs=dict(region_name="us-east-1"),
         )
         assert not df.empty
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -73,8 +73,8 @@ class Test_put_item:
         assert resp["Item"] == expected
 
     def test_existing_key_overwrites(self, ddb_client, empty_table):
-        """Test that putting an item for which the key already exists overwrites the item.
-        """
+        """Test that putting an item for which the key already exists overwrites the
+        item."""
         put_item(item=dict(id=0, A=0, B=1), table=empty_table)
 
         put_item(item=dict(id=0, A="abc"), table=empty_table)
@@ -421,7 +421,8 @@ class Test_get_all_items:
 
         # With the correct region we expect to get the items.
         items = get_all_items(
-            table=test_df_table, boto3_kwargs=dict(region_name="us-east-1"),
+            table=test_df_table,
+            boto3_kwargs=dict(region_name="us-east-1"),
         )
         assert items
 


### PR DESCRIPTION
Fix failing CI by replacing deprecated moto `mock_dynamodb2` with `mock_dynamodb`.

Also update pre-commit configuration to use latest version of black & reformat code accordingly.