### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/linux-checks.yml
+++ b/.github/workflows/linux-checks.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: "3.10"
     - name: Install tox
       run: |
         python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
   - id: black
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.7.0
+  rev: 5.12.0
   hooks:
   - id: isort
 
-- repo: https://gitlab.com/PyCQA/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 3.8.4
   hooks:
   - id: flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-black==19.10b0
+black==22.3.0
 coverage
 flake8==3.8.4
 interrogate
-isort==5.7.0
+isort==5.12.0
 moto
 pre-commit
 pytest

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+moto
+pytest
+pytest-cov
+pytest-randomly

--- a/tox.ini
+++ b/tox.ini
@@ -11,13 +11,14 @@ setenv =
 download = true
 deps =
     .[boto3]
-    -rrequirements-dev.txt
+    -rrequirements-test.txt
     pandas10: pandas>=1,<1.1
+    pandas10: numpy<=1.20
 commands = pytest -v --cov={envsitepackagesdir}/dynamo_pandas --cov-report term-missing {posargs}
 
 [testenv:linting]
-basepython = python3.7
-deps = -rrequirements-dev.txt
+basepython = python3.10
+deps = pre-commit
 skipdist = true
 usedevelop = true
 commands = pre-commit run --all-files

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
 commands = pytest -v --cov={envsitepackagesdir}/dynamo_pandas --cov-report term-missing {posargs}
 
 [testenv:linting]
-basepython = python3.10
+basepython = python310
 deps = pre-commit
 skipdist = true
 usedevelop = true


### PR DESCRIPTION
Multiple changes to fix broken CI:
- Run linting with Python3.10
- Update isort version to latest
- Change flake8 repo to github
- Only install pre-commit in linting environment
- Add test-specific requirements file with minimal requirements
- Pin numpy to <=1.20 for compatibility in pandas 1.0 environments