### PR TITLE
Include timedelta64 dtype conversion in tests & docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The project's documentation is available at https://dynamo-pandas.readthedocs.io
 
 
 ## Requirements
-* `python>=3.7`
-* `pandas>=1`
+* `python>=3.8`
+* `pandas>=1.2`
 * `boto3`
 
 ## Installation
@@ -59,7 +59,7 @@ The columns of the dataframe use different data types, some of which are not nat
 RangeIndex: 4 entries, 0 to 3
 Data columns (total 5 columns):
     #   Column        Non-Null Count  Dtype          
----  ------        --------------  -----          
+   ---  ------        --------------  -----          
     0   player_id     4 non-null      object         
     1   last_play     4 non-null      datetime64[ns] 
     2   play_time     4 non-null      timedelta64[ns]
@@ -134,12 +134,26 @@ The `dtype` parameter of the `get_df` function allows specifying the desired dat
 ...     dtype={
 ...         "bonus_points": "Int8",
 ...         "last_play": "datetime64[ns, UTC]",
-...         # "play_time": "timedelta64[ns]"  # See note below.
+...         "play_time": "timedelta64[ns]"  # See note below.
 ...     }
 ... )
+>>> df.info()
+
+<class 'pandas.core.frame.DataFrame'>
+RangeIndex: 2 entries, 0 to 1
+Data columns (total 5 columns):
+    #   Column        Non-Null Count  Dtype              
+   ---  ------        --------------  -----              
+    0   bonus_points  1 non-null      Int8               
+    1   player_id     2 non-null      object             
+    2   last_play     2 non-null      datetime64[ns, UTC]
+    3   rating        2 non-null      float64            
+    4   play_time     2 non-null      timedelta64[ns]    
+dtypes: Int8(1), datetime64[ns, UTC](1), float64(1), object(1), timedelta64[ns](1)
+memory usage: 196.0+ bytes
 ```
 
-**Note**: Due to a known bug in pandas, timedelta strings cannot currently be converted back to Timedelta type via this parameter (ref. https://github.com/pandas-dev/pandas/issues/38509). Use the pandas.to_timedelta function instead:
+**Note**: Due to a known bug in pandas versions < 1.5, timedelta strings cannot be converted back to Timedelta type via this parameter (ref. https://github.com/pandas-dev/pandas/issues/38509). If using pandas < 1.5, use the pandas.to_timedelta function instead:
 
 
 ```python
@@ -150,7 +164,7 @@ The `dtype` parameter of the `get_df` function allows specifying the desired dat
 RangeIndex: 2 entries, 0 to 1
 Data columns (total 5 columns):
     #   Column        Non-Null Count  Dtype              
----  ------        --------------  -----              
+   ---  ------        --------------  -----              
     0   bonus_points  1 non-null      Int8               
     1   player_id     2 non-null      object             
     2   last_play     2 non-null      datetime64[ns, UTC]

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -31,7 +31,7 @@ The columns of the dataframe use different data types, some of which are not nat
 RangeIndex: 4 entries, 0 to 3
 Data columns (total 5 columns):
     #   Column        Non-Null Count  Dtype          
----  ------        --------------  -----          
+   ---  ------        --------------  -----          
     0   player_id     4 non-null      object         
     1   last_play     4 non-null      datetime64[ns] 
     2   play_time     4 non-null      timedelta64[ns]
@@ -91,7 +91,7 @@ The ``dtype`` parameter of the ``get_df`` function allows specifying the desired
 ...     dtype={
 ...         "bonus_points": "Int8",
 ...         "last_play": "datetime64[ns, UTC]",
-...         # "play_time": "timedelta64[ns]"  # See note below.
+...         "play_time": "timedelta64[ns]"  # See note below.
 ...     }
 ... )
 >>> df.info()
@@ -104,11 +104,11 @@ Data columns (total 5 columns):
     1   player_id     2 non-null      object             
     2   last_play     2 non-null      datetime64[ns, UTC]
     3   rating        2 non-null      float64            
-    4   play_time     2 non-null      object
-dtypes: Int8(1), datetime64[ns, UTC](1), float64(1), object(2)
+    4   play_time     2 non-null      timedelta64[ns]
+dtypes: Int8(1), datetime64[ns, UTC](1), float64(1), object(1), timedelta64[ns](1)
 memory usage: 196.0+ bytes
 
-.. note:: Due to a `known bug in pandas <https://github.com/pandas-dev/pandas/issues/38509>`_, timedelta strings cannot currently be converted back to timedelta64 type via the ``dtype`` parameter. Use the ``pandas.to_timedelta`` function instead:
+.. note:: Due to a `known bug in pandas versions < 1.5 <https://github.com/pandas-dev/pandas/issues/38509>`_, timedelta strings cannot be converted back to timedelta64 type via the ``dtype`` parameter. If using pandas < 1.5, use the ``pandas.to_timedelta`` function instead:
 
     >>> df.play_time = pd.to_timedelta(df.play_time)
     >>> df.info()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ flake8==3.8.4
 interrogate
 isort==5.12.0
 moto
+packaging
 pre-commit
 pytest
 pytest-cov

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 moto[dynamodb]>=5,<6
+packaging
 pytest
 pytest-cov
 pytest-randomly


### PR DESCRIPTION
Fixes #24 

Include timedelta64 dtype conversion in tests & docs. Skip the specific tests in environments with pandas < 1.5 and update note in docs (README/overview) to indicate the pandas bug affects pandas versions < 1.5 only.